### PR TITLE
Add the possibility to load the docker image with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+image:
+  file: .devcontainer/Dockerfile

--- a/README.md
+++ b/README.md
@@ -17,5 +17,12 @@ run in the terminal
 docker build --build-arg USERNAME="your git user name" --build-arg USEREMAIL="your git email" --tag robotology_docker:$(date +%s) .devcontainer/
 ```
 
-In the [Dockerfile](https://github.com/Giulero/robotology_docker/blob/main/.devcontainer/Dockerfile) some compilation flags are handled (for now no Matlab).
+**or**
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Giulero/robotology_docker)
+
+
+
+---
+
+In the [Dockerfile](https://github.com/Giulero/robotology_docker/blob/main/.devcontainer/Dockerfile) some compilation flags are handled (for now no Matlab).


### PR DESCRIPTION
This PR adds the possibility to use the docker image with Gitpod


Once the PR has been merged, a working environment can be created by clicking on the following button added in the `README.md`

 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Giulero/robotology_docker)

Here an example:

![image](https://user-images.githubusercontent.com/16744101/103658245-40ab5f80-4f6b-11eb-890f-1907f57473a9.png)

cc @Giulero and @traversaro